### PR TITLE
fix model printing

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -19,21 +19,19 @@ $(TYPEDEF)
 
 ### Fields
 * `nvars` is the number of variables,
-* `nclique` is the number of cliques,
 * `cards` is a vector of cardinalities for variables,
 * `factors` is a vector of factors,
 """
 struct UAIModel{ET, FT <: Factor{ET}}
     nvars::Int
-    nclique::Int
     cards::Vector{Int}
     factors::Vector{FT}
 end
 
 Base.show(io::IO, ::MIME"text/plain", uai::UAIModel) = Base.show(io, uai)
 function Base.show(io::IO, uai::UAIModel)
-    println(io, "UAIModel(nvars = $(uai.nvars), nclique = $(uai.nclique))")
-    println(io, " variables :")
+    println(io, "UAIModel(nvars = $(uai.nvars), nfactors = $(length(uai.factors))")
+    println(io, " cards : $(uai.cards)")
     println(io, " factors : ")
     for (k, f) in enumerate(uai.factors)
         print(io, "  $(summary(f))")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,7 +59,7 @@ function read_model_from_string(str::AbstractString; factor_eltype = Float64)::U
     # Wrap the tables with their corresponding scopes in an array of Factor type
     factors = [Factor{factor_eltype, length(scope)}(Tuple(scope), table) for (scope, table) in zip(scopes_sorted, tables_sorted)]
 
-    return UAIModel(nvars, ntables, cards, factors)
+    return UAIModel(nvars, cards, factors)
 end
 
 """


### PR DESCRIPTION
I notice that there are some printing issue is the current documentation. Which will be fixed by this PR. I also removed the `nclique` field of the `UAIModel` type, which is not used anywhere in the code.

## Before the fix
The variables are not shown
![image](https://github.com/TensorBFS/TensorInference.jl/assets/6257240/b571da2d-8588-4355-871a-541deb70c065)


## After the fix
```
julia> using TensorInference

julia> model = read_model_file(pkgdir(TensorInference, "examples", "asia", "asia.uai"))
UAIModel(nvars = 8, nfactors = 8
 cards : [2, 2, 2, 2, 2, 2, 2, 2]
 factors : 
  Factor(1), size = (2,)
  Factor(1, 2), size = (2, 2)
  Factor(3), size = (2,)
  Factor(3, 4), size = (2, 2)
  Factor(3, 5), size = (2, 2)
  Factor(2, 4, 6), size = (2, 2, 2)
  Factor(6, 7), size = (2, 2)
  Factor(5, 6, 8), size = (2, 2, 2)
```