### PR TITLE
Return `Samples` type instead of a matrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorInference"
 uuid = "c2297e78-99bd-40ad-871d-f50e56b81012"
 authors = ["Jin-Guo Liu", "Martin Roa Villescas"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -59,6 +59,23 @@ struct TensorNetworkModel{LT, ET, MT <: AbstractArray}
     mars::Vector{Vector{LT}}
 end
 
+"""
+$TYPEDSIGNATURES
+
+Update the evidence of a tensor network model, without changing the set of observed variables!
+
+### Arguments
+- `tnet` is the [`TensorNetworkModel`](@ref) instance.
+- `evidence` is the new evidence, the keys must be a subset of existing evidence.
+"""
+function update_evidence!(tnet::TensorNetworkModel, evidence::Dict)
+    for (k, v) in evidence
+        haskey(tnet.evidence, k) || error("`update_evidence!` can only update observed variables!")
+        tnet.evidence[k] = v
+    end
+    return tnet
+end
+
 function Base.show(io::IO, tn::TensorNetworkModel)
     open = getiyv(tn.code)
     variables = join([string_var(var, open, tn.evidence) for var in tn.vars], ", ")

--- a/src/TensorInference.jl
+++ b/src/TensorInference.jl
@@ -23,7 +23,7 @@ export problem_from_artifact, ArtifactProblemSpec
 export read_model, UAIModel, read_evidence, read_solution, read_queryvars, dataset_from_artifact
 
 # marginals
-export TensorNetworkModel, get_vars, get_cards, log_probability, probability, marginals
+export TensorNetworkModel, get_vars, get_cards, log_probability, probability, marginals, update_evidence!
 
 # MAP
 export most_probable_config, maximum_logp

--- a/test/generictensornetworks.jl
+++ b/test/generictensornetworks.jl
@@ -12,6 +12,14 @@ using GenericTensorNetworks, TensorInference
     mars2 = TensorInference.normalize!(GenericTensorNetworks.solve(problem2, PartitionFunction(β)), 1)
     @test mars ≈ mars2
 
+    # update temperature
+    β2 = 3.0
+    model = update_temperature(model, problem, β2)
+    pa = probability(model)[]
+    model2 = TensorNetworkModel(problem, β2)
+    pb = probability(model2)[]
+    @test pa ≈ pb
+
     # mmap
     model = MMAPModel(problem, β; queryvars=[1,4])
     logp, config = most_probable_config(model)

--- a/test/mar.jl
+++ b/test/mar.jl
@@ -122,4 +122,13 @@ end
     tnet34 = TensorNetworkModel(model; openvars=[3,4])
     @test mars[1] ≈ probability(tnet23)
     @test mars[2] ≈ probability(tnet34)
+
+    tnet1 = TensorNetworkModel(model; mars=[[2, 3], [3, 4]], evidence=Dict(3=>1))
+    tnet2 = TensorNetworkModel(model; mars=[[2, 3], [3, 4]], evidence=Dict(3=>0))
+    mars1 = marginals(tnet1)
+    mars2 = marginals(tnet2)
+    update_evidence!(tnet1, Dict(3=>0))
+    mars1b = marginals(tnet1)
+    @test !(mars1 ≈ mars2)
+    @test mars1b ≈ mars2
 end

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -50,13 +50,13 @@ using TensorInference, Test
     tnet = TensorNetworkModel(model)
     samples = sample(tnet, n)
     mars = getindex.(marginals(tnet), 2)
-    mars_sample = [count(i->samples[k, i]==(1), axes(samples, 2)) for k=1:8] ./ n
+    mars_sample = [count(s->s[k]==(1), samples) for k=1:8] ./ n
     @test isapprox(mars, mars_sample, atol=0.05)
 
     # fix the evidence
     tnet = TensorNetworkModel(model, optimizer=TreeSA(), evidence=Dict(7=>1))
     samples = sample(tnet, n)
     mars = getindex.(marginals(tnet), 1)
-    mars_sample = [count(i->samples[k, i]==(0), axes(samples, 2)) for k=1:8] ./ n
+    mars_sample = [count(s->s[k]==(0), samples) for k=1:8] ./ n
     @test isapprox([mars[1:6]..., mars[8]], [mars_sample[1:6]..., mars_sample[8]], atol=0.05)
 end


### PR DESCRIPTION
Returning samples as a matrix is not intuitive, so I returned the a `Samples` instance instead. Since this is an API change, I bumped the middle version number.

I will merge and tagged it directly if the tests pass, since I need to deliver a lecture on Tursday.