### PR TITLE
Fix the overflow issue in probability

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -67,6 +67,7 @@ makedocs(;
         "Contributing" => "contributing.md",
     ],
     doctest = false,
+    warnonly = :missing_docs,
 )
 
 deploydocs(;

--- a/docs/src/api/public.md
+++ b/docs/src/api/public.md
@@ -66,4 +66,6 @@ read_model_file
 read_evidence_file
 read_td_file
 sample
+update_evidence!
+update_temperature
 ```

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -203,6 +203,16 @@ function log_probability(tn::TensorNetworkModel, config::Union{Dict, AbstractVec
     assign = config isa AbstractVector ? Dict(zip(get_vars(tn), config)) : config
     return sum(x -> log(x[2][(getindex.(Ref(assign), x[1]) .+ 1)...]), zip(getixsv(tn.code), tn.tensors))
 end
+"""
+$(TYPEDSIGNATURES)
+
+Evaluate the log probability (or partition function).
+It is the logged version of [`probability`](@ref), which is less likely to overflow.
+"""
+function log_probability(tn::TensorNetworkModel; usecuda = false)::AbstractArray
+    res = probability(tn; usecuda, rescale=true)
+    return asarray(res.log_factor .+ log.(res.normalized_value), res.normalized_value)
+end
 
 """
 $(TYPEDSIGNATURES)

--- a/src/mar.jl
+++ b/src/mar.jl
@@ -140,7 +140,7 @@ tensor network.
 - `rescale`: Specifies whether to rescale the tensors during contraction.
 
 ### Example
-The following example is taken from [`examples/asia-network/main.jl`](@ref).
+The following example is taken from [`examples/asia-network/main.jl`](https://tensorbfs.github.io/TensorInference.jl/dev/generated/asia-network/main/).
 
 ```jldoctest; setup = :(using TensorInference, Random; Random.seed!(0))
 julia> model = read_model_file(pkgdir(TensorInference, "examples", "asia-network", "model.uai"));

--- a/test/pr.jl
+++ b/test/pr.jl
@@ -23,7 +23,7 @@ using TensorInference
                 @info "Testing: $(problem_set_name)_$id"
                 tn = TensorNetworkModel(read_model(problem); optimizer, evidence=read_evidence(problem))
                 solution = log_probability(tn) / log(10) |> first
-                @test isapprox(solution, read_solution(problem); atol = 1e-3)
+                @test isapprox(solution, read_solution(problem); atol = 1e-3, rtol=1e-3)
             end
         end
     end

--- a/test/pr.jl
+++ b/test/pr.jl
@@ -22,9 +22,19 @@ using TensorInference
             for (id, problem) in problems[problem_set_name]
                 @info "Testing: $(problem_set_name)_$id"
                 tn = TensorNetworkModel(read_model(problem); optimizer, evidence=read_evidence(problem))
-                solution = probability(tn) |> first |> log10
+                solution = log_probability(tn) / log(10) |> first
                 @test isapprox(solution, read_solution(problem); atol = 1e-3)
             end
         end
     end
+end
+
+@testset "issue 77" begin
+    problems = dataset_from_artifact("uai2014")["PR"]
+    problem_set_name = "Alchemy"
+    optimizer = TreeSA(ntrials = 1, niters = 5, βs = 0.1:0.1:100)
+    id, problem = problems[problem_set_name] |> first
+    tn = TensorNetworkModel(read_model(problem); optimizer, evidence=read_evidence(problem))
+    solution = log_probability(tn) / log(10) |> first
+    @test isapprox(solution, read_solution(problem); atol=1e-3)
 end


### PR DESCRIPTION
fix #77 

The overflow issue has been seriously handled in this package by `RescaledArray`. However, when calling `probability`, we have to returns the exponentiated value, which causes the overflow in tests.
To avoid potential overflow, we added the logged version of this API:
```julia
julia> log_probability(tn)
```

It will return the logged value of the probability (or partition function), hence does not overflow.