### PR TITLE
Add a function to generate tensor network model by optimized EinCode

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -177,6 +177,21 @@ end
 
 """
 $(TYPEDSIGNATURES)
+"""
+function TensorNetworkModel(
+    model::UAIModel{T}, code;
+    evidence = Dict{Int,Int}(),
+    mars = [[i] for i=1:model.nvars],
+    vars = [1:model.nvars...]
+)::TensorNetworkModel where{T}
+    @debug "constructing tensor network model from code"
+    tensors = Array{T}[[ones(T, [model.cards[i] for i in mar]...) for mar in mars]..., [t.vals for t in model.factors]...]
+
+    return TensorNetworkModel(vars, code, tensors, evidence, mars)
+end
+
+"""
+$(TYPEDSIGNATURES)
 
 Get the variables in this tensor network, they are also known as legs, labels, or degree of freedoms.
 """

--- a/test/map.jl
+++ b/test/map.jl
@@ -2,6 +2,18 @@ using Test
 using OMEinsum
 using TensorInference
 
+@testset "load from code" begin
+    model = problem_from_artifact("uai2014", "MAR", "Promedus", 14)
+
+    tn1 = TensorNetworkModel(read_model(model);
+        evidence=read_evidence(model),
+        optimizer = TreeSA(ntrials = 3, niters = 2, βs = 1:0.1:80))
+    
+    tn2 = TensorNetworkModel(read_model(model), tn1.code, evidence=read_evidence(model))
+
+    @test tn1.code == tn2.code
+end
+
 @testset "gradient-based tensor network solvers" begin
     model = problem_from_artifact("uai2014", "MAR", "Promedus", 14)
 


### PR DESCRIPTION
The EinCode then can be pre-optimized, so that for all cases we are using the same contraction order.