### PR TITLE
Fix show method for the MMAP model

### DIFF
--- a/src/mmap.jl
+++ b/src/mmap.jl
@@ -37,7 +37,7 @@ function Base.show(io::IO, mmap::MMAPModel)
     tc, sc, rw = contraction_complexity(mmap)
     println(io, "$(typeof(mmap))")
     println(io, "variables: $variables")
-    println(io, "query variables: $(map(x->x.eliminated_vars, mmap.clusters))")
+    println(io, "query variables: $(join(string.(setdiff(get_vars(mmap), keys(mmap.evidence))), ", "))")
     print_tcscrw(io, tc, sc, rw)
 end
 Base.show(io::IO, ::MIME"text/plain", mmap::MMAPModel) = Base.show(io, mmap)


### PR DESCRIPTION
fix #93 

```julia
julia> mmap = MMAPModel(model, evidence=Dict(1 => 1, 8 => 1), queryvars=[4, 7])
MMAPModel{Int64, Array{Float64}}
variables: 1 (evidence → 1), 4, 7, 8 (evidence → 1)
query variables: 4, 7
contraction time = 2^29.356, space = 2^20.0, read-write = 2^22.673
```