### PR TITLE
Add conj with cost_and_gradient

### DIFF
--- a/src/belief.jl
+++ b/src/belief.jl
@@ -80,7 +80,7 @@ function _collect_message!(vectors_out::Vector, t::AbstractArray, vectors_in::Ve
     # TODO: speed up if needed!
     code = star_code(length(vectors_in))
     cost, gradient = cost_and_gradient(code, (t, vectors_in...))
-    for (o, g) in zip(vectors_out, gradient[2:end])
+    for (o, g) in zip(vectors_out, conj.(gradient[2:end]))
         o .= g
     end
     return cost[]

--- a/src/mar.jl
+++ b/src/mar.jl
@@ -78,6 +78,7 @@ probabilities of the queried variables, represented by tensors.
 function marginals(tn::TensorNetworkModel; usecuda = false, rescale = true)::Dict{Vector{Int}}
     # sometimes, the cost can overflow, then we need to rescale the tensors during contraction.
     cost, grads = cost_and_gradient(tn.code, (adapt_tensors(tn; usecuda, rescale)...,))
+    grads = conj.(grads)
     @debug "cost = $cost"
     ixs = OMEinsum.getixsv(tn.code)
     queryvars = ixs[tn.unity_tensors_idx]

--- a/test/belief.jl
+++ b/test/belief.jl
@@ -74,7 +74,9 @@ end
     mars = marginals(state)
     mars_tnet = marginals(tnet)
     for v in 1:TensorInference.num_variables(bp)
-        @test mars[[v]] ≈ mars_tnet[[v]] atol=1e-4
+        gauge = mars[[v]] ./ mars_tnet[[v]]
+        @test all(gauge .≈ gauge[1])
+        @test mars[[v]] ≈ gauge[1] .* mars_tnet[[v]] atol=1e-4
     end
 end
 

--- a/test/belief.jl
+++ b/test/belief.jl
@@ -46,7 +46,7 @@ end
 @testset "belief propagation" begin
     n = 5
     chi = 3
-    mps_uai = TensorInference.random_tensor_train_uai(Float64, n, chi)
+    mps_uai = TensorInference.random_tensor_train_uai(ComplexF64, n, chi)
     bp = BeliefPropgation(mps_uai)
     @test TensorInference.initial_state(bp) isa TensorInference.BPState
     state, info = belief_propagate(bp)
@@ -63,7 +63,7 @@ end
 @testset "belief propagation on circle" begin
     n = 10
     chi = 3
-    mps_uai = TensorInference.random_tensor_train_uai(Float64, n, chi; periodic=true)
+    mps_uai = TensorInference.random_tensor_train_uai(ComplexF64, n, chi; periodic=true) # FIXME: fail to converge
     bp = BeliefPropgation(mps_uai)
     @test TensorInference.initial_state(bp) isa TensorInference.BPState
     state, info = belief_propagate(bp; max_iter=100, tol=1e-6)


### PR DESCRIPTION
Try fixing https://github.com/TensorBFS/TensorInference.jl/issues/98

- Still FAIL to pass the "belief propagation on circle" test (ComplexF64 version), where BP fails to converge.
- There are four parts involving `cost_and_gradient` and I only edited `belief.jl`, `mar.jl` and leave those in `map.jl` and `mmap.jl` remained the same.
- I am not sure if it is correct to conjugate tensors when the datatype is neither Real nor Complex.